### PR TITLE
Updating setup.py for Python 3.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name = "Captain Panda--Across the Night",
-    version = "1.0.3",
+    version = "1.0.4",
     options = {
         "build_apps" : {
             "include_patterns" : [
@@ -44,7 +44,7 @@ setup(
                 "p3openal_audio",
             ],
             "platforms" : [
-                "manylinux1_x86_64",
+                "manylinux2014_x86_64",
                 #"macosx_10_6_x86_64",
                 "win_amd64"
             ],


### PR DESCRIPTION
Python 3.11 is not available for manylinux1, it requires manylinux2014 . 

Additionally I have updated the game's version string to "1.0.4" to reflect the shader hitch fix implementation.